### PR TITLE
django>=1.4 in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
     long_description=README,
     install_requires=[
         'jsonpickle>=0.4.0',
-        'django==1.4',
+        'django>=1.4',
         'djangorestframework>=2.1.3'
     ],
 


### PR DESCRIPTION
Seems to work fine with django 1.5. And django==1.4 in setup.py makes pip downgrade my django version
