### PR TITLE
Flatten urls when manually specifying url patterns

### DIFF
--- a/rest_framework_docs/docs.py
+++ b/rest_framework_docs/docs.py
@@ -24,6 +24,8 @@ class DocumentationGenerator():
         """
         if urlpatterns is None:
             urlpatterns = self.get_url_patterns()
+        else:
+            urlpatterns = self._flatten_patterns_tree(urlpatterns)
 
         self.urlpatterns = urlpatterns
 


### PR DESCRIPTION
When manually [specifying the url patterns](https://github.com/pleasedontbelong/django-rest-framework-docs#specify-your-own-url-patterns) You get an error `'RegexURLPattern' object has no attribute '_DocumentationGenerator__path'` because RegexURLPattern doesn't have a `__path` attribute
